### PR TITLE
Modify API to support track names and total duration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "time-tunes",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "src_tauri"
-version = "0.1.1"
+version = "0.1.2"
 description = "Make the perfect playlist for any duration"
 authors = ["Aria", "Slushee"]
 repository = "https://github.com/lxbx44/time-tunes"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -94,7 +94,7 @@ impl Playlist {
     pub fn unused_len(&self) -> usize {
         self.unused.len()
     }
-    
+
     // TODO: Implement actual metadata name checking and clean up this mess
     /// Returns a list with the paths of the songs in the playlist, their name and the total
     /// duration of the playlist in seconds

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -94,16 +94,26 @@ impl Playlist {
     pub fn unused_len(&self) -> usize {
         self.unused.len()
     }
-
-    /// Returns a list with the paths of the songs in the playlist
+    
+    // TODO: Implement actual metadata name checking and clean up this mess
+    /// Returns a list with the paths of the songs in the playlist, their name and the total
+    /// duration of the playlist in seconds
     ///
     /// # Panics
     /// - Panics if a path contains non UTF-8 glyphs
-    pub fn get(&self) -> Vec<String> {
-        self.used
-            .par_iter()
-            .map(|s| s.0.to_str().unwrap().to_owned())
-            .collect()
+    pub fn get(&self) -> (Vec<(String, String)>, u64) {
+        (
+            self.used
+                .par_iter()
+                .map(|s| {
+                    (
+                        s.0.to_str().unwrap().to_owned(),
+                        s.0.file_name().unwrap().to_str().unwrap().to_owned(),
+                    )
+                })
+                .collect(),
+            self.used_duration.as_secs(),
+        )
     }
 
     /// Attempts to swap the selected audio track `depth` times accortding to the provided heuristics

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -8,7 +8,8 @@ const DEPTH_FACTOR: usize = 100;
 const STEPS_FACTOR: usize = 100;
 const LOOPS: usize = 1;
 
-/// retrieves a list of music files according to the user provided settings
+/// retrieves a list of music files according to the user provided settings and the total duration
+/// of the of the list
 ///
 /// # Assumptions
 ///  - `time` is an unsigned integer representing seconds
@@ -19,9 +20,8 @@ const LOOPS: usize = 1;
 ///  - `Steps` parameter
 ///  - `Loops` parameter
 ///  - `h` parameter
-
 #[tauri::command]
-fn get_playlist(time: u64, path: &str) -> Vec<String> {
+fn get_playlist(time: u64, path: &str) -> (Vec<(String, String)>, u64) {
     let audio_files = get_audio_files(&PathBuf::from(path));
     let duration = Duration::from_secs(time);
     let mut playlist = Playlist::from_random(audio_files, duration);

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
     },
     "package": {
         "productName": "time-tunes",
-        "version": "0.1.1"
+        "version": "0.1.2"
     },
     "tauri": {
         "allowlist": {


### PR DESCRIPTION
## Changed
 - Modified `Playlist::get()`'s API to support returning song names along with the total duration of the playlist
 - Bumped version
 
## TODO
 - Implement actual metadata checking