### PR TITLE
Fix same song bug

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -248,7 +248,7 @@ impl Playlist {
     /// - `index` is contained in playlist.used
     /// - `playlist.used_duration` has been correctly calculated
     pub fn swap(&mut self, index: usize, depth: usize, h: Heuristics) -> &mut Self {
-        let swap_attempts: Vec<(usize, &(PathBuf, Duration))> = self
+        let swap_attempts = self
             .unused
             .iter()
             .enumerate()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -173,7 +173,7 @@ impl MetadataBuilder {
             artist: self.artist.unwrap_or_else(|| DEFAULT.to_owned()),
             album: self.album.unwrap_or_else(|| DEFAULT.to_owned()),
             picture: self.picture,
-            mimetype: self.mimetype.unwrap_or(DEFAULT.to_owned()),
+            mimetype: self.mimetype.unwrap_or_else(|| DEFAULT.to_owned()),
             duration: self.duration.unwrap_or_default(),
         }
     }


### PR DESCRIPTION
Without this fix applied, it is possible for the `lib::swap()` function to put a duplicate song in the playlist, which is unintended behavior.

## Changes
 - Removes swapped songs from the `unused` list so they can't be swapped in again
 - Update heuristics signature in preparation for new definitions