### PR TITLE
Add middleground heuristics function

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "time-tunes",
   "private": true,
-  "version": "0.2.1",
+  "version": "0.2.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "src_tauri"
-version = "0.2.1"
+version = "0.2.2"
 description = "Make the perfect playlist for any duration"
 authors = ["Aria", "Slushee"]
 repository = "https://github.com/lxbx44/time-tunes"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -295,8 +295,42 @@ pub fn h_greedy(
     let new_total = new_total.as_secs_f64();
     let target = target.as_secs_f64();
 
-    if (target - new_total).abs() < (target - old_total).abs() {
+    let old_diff = (target - old_total).abs();
+    let new_diff = (target - new_total).abs();
+
+    if new_diff < old_diff {
         return true;
     }
+
+    false
+}
+
+/// Will return true if
+///  - the duration is closer to the target
+///  and
+///  - the old total is further from the target than it is to the new total
+///
+/// Attempts to create a smoother convergence and better distributed length of the songs by not
+/// immediately jumping to the smallest distance to target
+pub fn h_middleground(
+    original_total: Duration,
+    old_total: Duration,
+    new_total: Duration,
+    target: Duration,
+) -> bool {
+    let original_total = original_total.as_secs_f64();
+    let old_total = old_total.as_secs_f64();
+    let new_total = new_total.as_secs_f64();
+    let target = target.as_secs_f64();
+
+    let old_diff = (target - old_total).abs();
+    let new_diff = (target - new_total).abs();
+    let original_diff = (target - original_total).abs();
+    let new_n_original_diff = (original_total - new_total).abs();
+
+    if new_diff < old_diff && new_n_original_diff <= original_diff {
+        return true;
+    }
+
     false
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
     },
     "package": {
         "productName": "time-tunes",
-        "version": "0.2.1"
+        "version": "0.2.2"
     },
     "tauri": {
         "allowlist": {


### PR DESCRIPTION
## Adds
 - `h_middleground` heuristics function, which attempts to have a smoother (and therefore probably slower) convergence of the playlist duration.

## Changes
 - Bump version

## Comments
I'm thinking I could modify the `lib::swap()` function to either take a closure, a trait object or maybe use a macro. That way the signature for the heuristics function doesn't have to be fixed, allowing for more flexible functions that decide based on other factors like being on the same album or from the same artist.
Let me know if you'd be interested on something like this